### PR TITLE
Binary named incorrectly

### DIFF
--- a/static/install
+++ b/static/install
@@ -21,6 +21,6 @@ echo "Downloading $repo/$binary"
 curl -L -s -o /tmp/shipyard.zip "$repo/$binary"
 cd /tmp
 unzip shipyard.zip
-sudo mv yard2 /usr/local/bin/shipyard
-sudo chmod +x /usr/local/bin/shipyard
+sudo mv yard2 /usr/local/bin/yard2
+sudo chmod +x /usr/local/bin/yard2
 rm shipyard.zip


### PR DESCRIPTION
The binary name is set to `shipyard` instead of `yard2`. We use `yard2` in the docs. 
https://shipyard.run/docs/install#running-your-first-blueprint