### PR TITLE
Updates repository link for Nomad example and make blueprints easier to copy

### DIFF
--- a/docs/resources/exec_remote.md
+++ b/docs/resources/exec_remote.md
@@ -111,14 +111,14 @@ Running configuration from:  ./examples/exec_remote/exec_container
 ## Parameters
 
 
-### depends_on 
+### depends_on
 **Type: []string**  
 **Required: false**
 
 Depends on allows you to specify resources which should be created before this one. In the instance of a destruction, this container will be destroyed before
 resources in.
 
-### target 
+### target
 **Type: string**  
 **Required: false**
 

--- a/docs/resources/exec_remote.md
+++ b/docs/resources/exec_remote.md
@@ -48,6 +48,9 @@ exec_remote "exec_standalone" {
 
 ```shell
 ➜ shipyard run github.com/shipyard-run/shipyard-website/examples/exec_remote/exec_stand_alone
+```
+
+```shell
 Running configuration from:  examples/exec_remote/exec_container
 
 2020-04-29T09:15:23.331+0100 [DEBUG] Statefile does not exist
@@ -84,6 +87,11 @@ exec_remote "exec_container" {
 
 ```shell
 ➜ shipyard run github.com/shipyard-run/shipyard-website/examples/exec_remote/exec_container
+```
+
+Example output:
+
+```shell
 Running configuration from:  ./examples/exec_remote/exec_container
 
 2020-04-29T09:09:48.593+0100 [DEBUG] Statefile does not exist
@@ -97,7 +105,6 @@ Running configuration from:  ./examples/exec_remote/exec_container
 2020-04-29T09:10:05.187+0100 [INFO]  Remote executing command: ref=exec_container command=consul args=[services, register, /config/redis.hcl] image=<nil>
 2020-04-29T09:10:05.189+0100 [DEBUG] 
 2020-04-29T09:10:05.435+0100 [DEBUG] Registered service: redis
-
 ```
 
 

--- a/docs/resources/k8s_cluster.md
+++ b/docs/resources/k8s_cluster.md
@@ -3,7 +3,7 @@ id: k8s_cluster
 title: Kubernetes Cluster
 ---
 
-The `k8s_cluster` resource allows the creation of Kubernetes clusters running in Docker. 
+The `k8s_cluster` resource allows the creation of Kubernetes clusters running in Docker.
 
 ## Minimal example
 
@@ -50,7 +50,7 @@ Besides using local tooling to deploy applications to your cluster you can use t
 
 The following example shows a `helm` resource which would install a remote Helm chart for HashiCorp Vault.
 
-Since Shipyard has a full understanding of the dependencies in your application the `helm` charts do not run until the cluster is fully up and running. Simply referencing the cluster in the `helm` chart stanza is the only thing required. Health checks can also be added to `helm` chart resources ensuring the next step of the dependency chain does not start before the applicaiton is running. 
+Since Shipyard has a full understanding of the dependencies in your application the `helm` charts do not run until the cluster is fully up and running. Simply referencing the cluster in the `helm` chart stanza is the only thing required. Health checks can also be added to `helm` chart resources ensuring the next step of the dependency chain does not start before the applicaiton is running.
 
 For more information on the `helm` resource type please see the documentation for that resource `/docs/resources/helm`.
 
@@ -113,7 +113,7 @@ k8s_ingress "vault-http" {
 
 ## Parameters
 
-### depends_on 
+### depends_on
 **Type: []string**  
 **Required: false**
 
@@ -149,7 +149,7 @@ Number of client nodes to create for a cluster, a value of 1 creates a combined 
 **Type: [[]image](#type-image)**  
 **Required: false**
 
-The `image` block allows you to specifiy images which will be copied from the local cache to the remote cluster. Kubernetes clusters have their own local Docker image cache, if images are not preloaded to the local cache then Kubernetes will attempt to retrieve these from a remote repository when starting a container. 
+The `image` block allows you to specifiy images which will be copied from the local cache to the remote cluster. Kubernetes clusters have their own local Docker image cache, if images are not preloaded to the local cache then Kubernetes will attempt to retrieve these from a remote repository when starting a container.
 
 `image` can also be used to push local builds which are not stored in a remote container registry.
 
@@ -158,7 +158,7 @@ Can be specified multiple times.
 
 ## Type `image`
 
-Image defines a Docker image used when creating this container. An Image can be stored in a public or a private repository.  
+Image defines a Docker image used when creating this container. An Image can be stored in a public or a private repository.
 
 ### name
 **Type: `string`**  

--- a/docs/resources/nomad_cluster.md
+++ b/docs/resources/nomad_cluster.md
@@ -20,5 +20,5 @@ network {
 ```
 
 ```
-shipyard run github.com/shipyard-website/examples/nomad_cluster//minimal
+shipyard run github.com/shipyard-run/shipyard-website/examples/nomad_cluster//minimal
 ```

--- a/docs/resources/sidecar.md
+++ b/docs/resources/sidecar.md
@@ -82,14 +82,14 @@ Inspect the Service:
 
 ## Parameters
 
-### depends_on 
+### depends_on
 **Type: []string**  
 **Required: false**
 
 Depends on allows you to specify resources which should be created before this one. In the instance of a destruction, this container will be destroyed before
 resources in.
 
-### target 
+### target
 **Type: string**  
 **Required: true**
 
@@ -116,7 +116,7 @@ command = [
 ]
 ```
 
-Entrypoint can be used in addition with `command`, Docker containers often define an entrypoint which configures the base command to run, `command` is then used to specifcy additional parameters. 
+Entrypoint can be used in addition with `command`, Docker containers often define an entrypoint which configures the base command to run, `command` is then used to specifcy additional parameters.
 
 ### command
 **Type: []string**  
@@ -183,7 +183,7 @@ health_check {
 
 ## Type `image`
 
-Image defines a Docker image used when creating this container. An Image can be stored in a public or a private repository.  
+Image defines a Docker image used when creating this container. An Image can be stored in a public or a private repository.
 
 ### name
 **Type: `string`**  

--- a/docs/resources/sidecar.md
+++ b/docs/resources/sidecar.md
@@ -58,7 +58,11 @@ network "cloud" {
 
 ```shell
 shipyard run github.com/shipyard-run/shipyard-website/examples/sidecar//minimal
+```
 
+Inspect the Service:
+
+```shell
 ➜ curl localhost:8080
 {
   "name": "Service",


### PR DESCRIPTION
Hey folks, 

two changes in this:

1.) the Nomad example was missing the GitHub organization and thus wouldn't run. This has been updated

2.) some blueprints included more information in their code box than was needed to `shipyard run` them; thus clicking copy resulted in running more commands, some of which would break (in the case of the `curl` output)

I fixed both and removed a few trailing spaces that were around in the files. Happy to keep that out of this PR and submit a stand-alone one if so desired.